### PR TITLE
Fix undefined variable when registering an organization

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -84,6 +84,7 @@ class Runner:
     def remove_runners(self, offline_only=True, timeout=30):
         """Remove runners"""
         api = self.api
+        repo = None
         if "/" in self.path:
             owner, repo = self.path.split("/")
         for id in self._find_offline_runners(timeout=timeout):


### PR DESCRIPTION
Hit an issue deploying for charmed-kubernetes, tested this directly on the unit's and they registered with the fix.