### PR TITLE
Privileged is required for snaps in unconfined containers

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -225,6 +225,7 @@ class Runner:
         if not self.lxd.profiles.exists("runner"):
             config = {
                 "security.nesting": "true",
+                "security.privileged": "true",
                 "raw.lxc": "lxc.apparmor.profile=unconfined",
             }
             devices = {}


### PR DESCRIPTION
Apparently you need to be privileged *and* unconfined to output stdout in a classic snap in a LXD container. The other option is remove both priviliged and the unconfined profile and it will also run but be denied access to stdout. I'm leaning toward getting the debug logging.