### PR TITLE
Load apparmor profiles

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -21,6 +21,7 @@ def mocks(monkeypatch):
     monkeypatch.setattr("runner.requests", mock.MagicMock())
     monkeypatch.setattr("runner.Runner._check_output", mock.MagicMock())
     monkeypatch.setattr("runner.Runner._get_runner_binary", mock.MagicMock())
+    monkeypatch.setattr("runner.Runner._load_aaprofile", mock.MagicMock())
 
     def active_count(runner_class, values=[0, 1, 2, 3]):
         return values.pop(0)


### PR DESCRIPTION
After several tests, I've found that loading the profiles via apparmor_parser allows juju to run. However, I believe it's racing as some calls return an error (239). I've not seen any errors on the first call to /etc/apparmor.d/*snap-confine*.

I've also added an option to not split the command that is passed into the check_output call. This was necessary so to launch bash for the shell expansion.

I've done a fresh install with this build, and it has been getting past bootstrap again. This run was made against this build of the charm: https://github.com/charmed-kubernetes/charm-kubernetes-worker/runs/2635431830?check_suite_focus=true