### PR TITLE
Refactor runner management logic

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -6,4 +6,8 @@
 # It ties in to the example _on_fortune_action handler in src/charm.py
 # 
 check-runners:
-    description: Bring runner count in sync with config and remove offline runners
+    description: Get info on active and registered runners
+reconcile-runners:
+    description: Remove offline runners and replace any missing runners
+flush-runners:
+    description: Clear out all runners and start a new set

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,8 @@
+type: charm
+bases:
+  - build-on:
+    - name: "ubuntu"
+      channel: "20.04"
+    run-on:
+    - name: "ubuntu"
+      channel: "20.04"

--- a/config.yaml
+++ b/config.yaml
@@ -11,10 +11,14 @@ options:
       default: 3
       type: int
       description: "Quantity of runners to maintain"
-  check-interval:
-      default: "*/1 * * * *"
-      type: string
-      description: "Cron interval to check runners, each deployed unit will check on this interval"
+  reconcile-interval:
+      default: 5
+      type: int
+      description: "How frequently, in minutes, the runners should be reconciled"
+  update-interval:
+      default: 60
+      type: int
+      description: "How frequently, in minutes, the charm should check for new versions of the runner binary"
   virt-type:
       default: "container"
       type: string

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ requests
 jinja2
 ghapi
 pylxd
-python-crontab

--- a/scripts/dispatch-event.sh
+++ b/scripts/dispatch-event.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-unit="$1"
-event="$2"
-timeout="$3"
-
-flock -n -E 0 "/run/github-runner-operator/$event" -- juju-run "$unit" "JUJU_DISPATCH_PATH=$event timeout $timeout ./dispatch"

--- a/scripts/dispatch-event.sh
+++ b/scripts/dispatch-event.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+unit="$1"
+event="$2"
+timeout="$3"
+
+flock -n -E 0 "/run/github-runner-operator/$event" -- juju-run "$unit" "JUJU_DISPATCH_PATH=$event timeout $timeout ./dispatch"

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,13 +9,17 @@ from ops.charm import CharmBase
 from ops.framework import EventBase, StoredState
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
-from runner import Runner
+from runner import RunnerManager, RunnerError
 
 logger = logging.getLogger(__name__)
 
 
-class CheckRunnersEvent(EventBase):
-    """Event to request a runner check"""
+class ReconcileRunnersEvent(EventBase):
+    """Event representing a periodic check to ensure runners are ok."""
+
+
+class UpdateRunnerBinEvent(EventBase):
+    """Event representing a periodic check for new versions of the runner binary."""
 
 
 class GithubRunnerOperator(CharmBase):
@@ -23,94 +27,218 @@ class GithubRunnerOperator(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.on.define_event("check_runners", CheckRunnersEvent)
+
+        self._stored.set_default(
+            path=self.config["path"],  # for detecting changes
+            runner_bin_url=None,
+        )
+        self._cron_tab = CronTab
+
+        self.on.define_event("reconcile_runners", ReconcileRunnersEvent)
+        self.on.define_event("update_runner_bin", UpdateRunnerBinEvent)
+
+        self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.on.reconcile_runners, self._on_reconcile_runners)
+        self.framework.observe(self.on.update_runner_bin, self._on_update_runner_bin)
+        self.framework.observe(self.on.stop, self._on_stop)
+
         self.framework.observe(
             self.on.check_runners_action, self._on_check_runners_action
         )
-        self.framework.observe(self.on.install, self._on_install)
-        self.framework.observe(self.on.stop, self._on_stop)
-        self.framework.observe(self.on.check_runners, self._on_check_runners)
-        self._stored.set_default(path="")
-        self._runner = Runner(self.config["path"], self.config["token"])
-        self._cron_tab = CronTab
+        self.framework.observe(
+            self.on.reconcile_runners_action, self._on_reconcile_runners_action
+        )
+        self.framework.observe(
+            self.on.flush_runners_action, self._on_flush_runners_action
+        )
+
+    def _get_runner_manager(self, token=None, path=None):
+        """Get a RunnerManager instance, or None if missing config."""
+        if token is None:
+            token = self.config["token"]
+        if path is None:
+            path = self.config["path"]
+        if not (token and path):
+            return None
+        return RunnerManager(path, token, self.app.name)
 
     def _on_install(self, event):
         self.unit.status = MaintenanceStatus("Installing packages")
-        self._runner.install()
+        RunnerManager.install_deps()
+        runner_manager = self._get_runner_manager()
+        if runner_manager:
+            self.unit.status = MaintenanceStatus("Installing runner binary")
+            try:
+                self._stored.runner_bin_url = runner_manager.get_latest_runner_bin_url()
+                runner_manager.update_runner_bin(self._stored.runner_bin_url)
+            except Exception as e:
+                logger.exception("Failed to update runner binary")
+                self.unit.status = BlockedStatus(f"Failed to update runner binary: {e}")
+                return
+            self.unit.status = MaintenanceStatus("Starting runners")
+            try:
+                runner_manager.reconcile(self.config["quantity"])
+            except RunnerError as e:
+                logger.exception("Failed to start runners")
+                self.unit.status = BlockedStatus(f"Failed to start runners: {e}")
+            else:
+                self.unit.status = ActiveStatus()
 
     def _on_config_changed(self, event):
-        if self._stored.path:
-            if self._stored.path != self.config["path"]:
-                logger.error("Changing path not supported")
-                self.unit.status = BlockedStatus("Path can not be changed")
+        self._ensure_cron("update-runner-bin", self.config["update-interval"])
+        self._ensure_cron("reconcile-runners", self.config["reconcile-interval"])
+
+        if self.config["path"] != self._stored.path:
+            prev_runner_manager = self._get_runner_manager(path=self._stored.path)
+            if prev_runner_manager:
+                self.unit.status = MaintenanceStatus(
+                    "Removing runners from old org/repo"
+                )
+                prev_runner_manager.clear()
+            self._stored.path = self.config["path"]
+
+        runner_manager = self._get_runner_manager()
+        if not runner_manager:
+            self.unit.status = BlockedStatus("Missing token or org/repo path config")
+            return
+
+    def _on_update_runner_bin(self, event):
+        runner_manager = self._get_runner_manager()
+        if not runner_manager:
+            return
+        old_status = self.unit.status
+        self.unit.status = MaintenanceStatus("Checking for runner updates")
+        runner_bin_url = runner_manager.get_latest_runner_bin_url()
+        if runner_bin_url != self._stored.runner_bin_url:
+            self.unit.status = MaintenanceStatus("Updating runner binary")
+            try:
+                runner_manager.update_runner_bin(runner_bin_url)
+            except Exception as e:
+                logger.exception("Failed to update runner binary")
+                self.unit.status = BlockedStatus(f"Failed to update runner binary: {e}")
                 return
+            self._stored.runner_bin_url = runner_bin_url
+            # TODO: Flush existing runners? What if they're processing a job?
+        self.unit.status = old_status
+
+    def _on_reconcile_runners(self, event):
+        runner_manager = self._get_runner_manager()
+        if not runner_manager:
+            return
+        self.unit.status = MaintenanceStatus("Reconciling runners")
+        try:
+            self.runner_manager.reconcile(self.config["quantity"])
+        except RunnerError as e:
+            self.unit.status = BlockedStatus(f"Failed to reconcile runners: {e}")
         else:
-            if self.config["path"]:
-                self._stored.path = self.config["path"]
-
-        if not (self.config["token"] and self._stored.path):
-            self.unit.status = BlockedStatus("Waiting for Token and Path config")
-            return
-
-        self._reconcile_runners()
-        self._add_cron("check-runners", self.config["check-interval"])
-
-    def _on_check_runners(self, event):
-        if not (self.config["token"] and self._stored.path):
-            logger.info("Not checking runners, missing config")
-            return
-        self._reconcile_runners()
+            self.unit.status = ActiveStatus()
 
     def _on_check_runners_action(self, event):
-        if not (self.config["token"] and self._stored.path):
-            event.set_results({"status": "Check aborted, config options missing"})
+        runner_manager = self._get_runner_manager()
+        if not runner_manager:
+            event.fail("Missing token or org/repo path config")
             return
 
-        self._reconcile_runners()
-        event.set_results({"status": "Completed runner check"})
+        offline = 0
+        unregistered = 0
+        active = 0
+        unknown = 0
 
-    def _reconcile_runners(self):
-        delta = self.config["quantity"] - self._runner.active_count()
-        logger.info(f"Reconciling {delta} runners")
-        while delta > 0:
-            self.unit.status = MaintenanceStatus(f"Installing {delta} runner(s)")
-            try:
-                self._runner.create(image="ubuntu", virt=self.config["virt-type"])
-            except RuntimeError as e:
-                logger.error("Failed to create runner")
-                logger.error(f"Error: {e}")
-            delta = self.config["quantity"] - self._runner.active_count()
-        self.unit.status = ActiveStatus("Active and registered")
+        try:
+            runner_info = runner_manager.get_info()
+        except RunnerError as e:
+            event.fail(f"Failed to get runner info: {e}")
+            return
+
+        for runner in runner_info:
+            if runner.is_active:
+                active += 1
+            elif runner.is_offline:
+                offline += 1
+            elif runner.is_unregistered:
+                unregistered += 1
+            else:
+                # might happen if runner dies and GH doesn't notice immediately
+                unknown += 1
+        event.set_results(
+            {
+                "offline": offline,
+                "unregistered": unregistered,
+                "active": active,
+                "unknown": unknown,
+            }
+        )
+
+    def _on_reconcile_runners_action(self, event):
+        runner_manager = self._get_runner_manager()
+        if not runner_manager:
+            event.fail("Missing token or org/repo path config")
+            return
+
+        try:
+            delta = runner_manager.reconcile(self.config["quantity"])
+        except RunnerError as e:
+            event.fail(f"Failed to reconcile runners: {e}")
+            return
+        self._on_check_runners_action(event)
+        event.set_results({"delta": delta})
+
+    def _on_flush_runners_action(self, event):
+        runner_manager = self._get_runner_manager()
+        if not runner_manager:
+            event.fail("Missing token or org/repo path config")
+            return
+
+        try:
+            runner_manager.clear()
+            delta = runner_manager.reconcile(self.config["quantity"])
+        except RunnerError as e:
+            event.fail(f"Failed to flush runners: {e}")
+            return
+        self._on_check_runners_action(event)
+        event.set_results({"delta": delta})
 
     def _on_stop(self, event):
-        self._remove_cron("check-runners")
-        self._runner.remove_runners()
+        self._remove_cron("update-runner-bin")
+        self._remove_cron("reconcile-runners")
+        runner_manager = self._get_runner_manager()
+        if runner_manager:
+            runner_manager.clear()
 
-    def _add_cron(self, event, interval):
-        """Add a cron job for the provided event to run at the provided interval."""
+    def _ensure_cron(self, event_name, interval, timeout=...):
+        """Add a cron job to dispatch an event.
+
+        Only one cron job can be registered per event; duplicates will replace an existing
+        job. The event will be dispatched to the charm code via `juju-run`.
+
+        Currently supported events are: reconcile-runners
+
+        The interval is how frequently, in minutes, that the event should be dispatched.
+
+        The timeout is the number of seconds before an event is timed out. If not given,
+        it defaults to half the interval period.
+        """
+        if timeout is ...:
+            timeout = interval * 60 / 2
+
+        # Remove existing entries before adding the new with a possibly updated interval
+        self._remove_cron(event_name)
+
         root_cron = self._cron_tab(user="root")
-        comment = f"Charm cron for {event}"
-
-        # Remove if it exists and write with the possibly updated interval
-        self._remove_cron(event)
-
-        unit = self.unit.name
-        dispatch = str(self.charm_dir / "dispatch")
-        command = f"juju-run {unit} 'JUJU_DISPATCH_PATH={event} {dispatch}'"
+        comment = f"Charm cron for {event_name}"
+        dispatch = self.charm_dir / "scripts" / "dispatch-event.sh"
+        command = f"{dispatch} {self.unit.name} {event_name} {timeout}"
         job = root_cron.new(command=command, comment=comment)
-        job.setall(interval)
+        job.setall(f"*/{interval} * * * *")
         root_cron.write()
 
-    def _remove_cron(self, event):
+    def _remove_cron(self, event_name):
         """Remove cron job for provided event."""
         root_cron = self._cron_tab(user="root")
-        try:
-            job = next(root_cron.find_comment(f"Charm cron for {event}"))
+        for job in root_cron.find_comment(f"Charm cron for {event_name}"):
             root_cron.remove(job)
-            root_cron.write()
-        except StopIteration:
-            pass  # Not found
+        root_cron.write()
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -232,7 +232,7 @@ class GithubRunnerOperator(CharmBase):
                 logger.exception("Failed to clear runners")
 
     def _render_event_tmpl(self, tmpl_type, event_name, context):
-        tmpl = self.jinja.get_template(f"dispatch-event.{tmpl_type}.j2")
+        tmpl = self._jinja.get_template(f"dispatch-event.{tmpl_type}.j2")
         dest = self._systemd_path / f"ghro.{event_name}.{tmpl_type}"
         dest.write_text(tmpl.render(context))
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -152,9 +152,7 @@ class RunnerManager:
                 org=self.path
             )["runners"]
         remote_runners = {
-            r.name: r
-            for r in remote_runners
-            if r.name.startswith(f"{self.app_name}-")
+            r.name: r for r in remote_runners if r.name.startswith(f"{self.app_name}-")
         }
         runners = []
         for name in set(local_runners.keys()) & set(remote_runners.keys()):
@@ -186,7 +184,7 @@ class RunnerManager:
                 self._runner.create(image="ubuntu", virt=self.virt_type)
         elif delta < 0:
             active_runners.sort(key=lambda r: r.created_at)
-            old_runners = active_runners[abs(delta):]
+            old_runners = active_runners[abs(delta) :]
             runner_names = ", ".join(r.name for r in old_runners)
             logger.info(f"Removing extra runners: {runner_names}")
             for runner in old_runners:

--- a/src/runner.py
+++ b/src/runner.py
@@ -67,9 +67,7 @@ class RunnerRemoveFailed(RunnerError):
 
 class RunnerManager:
     runner_bin_path = Path("/var/cache/github-runner-operator/runner.tgz")
-    lock_dir_path = Path("/run/github-runner-operator")
-    runner_path = Path("/opt/github-runner")
-    env_file = runner_path / ".env"
+    env_file = Path("/opt/github-runner/.env")
 
     def __init__(self, path, token, app_name, virt_type):
         http_proxy = os.environ.get("JUJU_CHARM_HTTP_PROXY", None)
@@ -102,7 +100,6 @@ class RunnerManager:
         """Install dependencies"""
         subprocess.run(["snap", "install", "lxd"], check=True)
         subprocess.run(["lxd", "init", "--auto"], check=True)
-        cls.lock_dir_path.mkdir(exist_ok=True)
         cls.runner_bin_path.parent.mkdir(parents=True, exist_ok=True)
 
     def get_latest_runner_bin_url(self):
@@ -240,7 +237,9 @@ class RunnerManager:
                         org=self.path, runner_id=runner.remote.id
                     )
             except Exception as e:
-                raise RunnerRemoveFailed(f"Failed remove remote runner: {runner.name}") from e
+                raise RunnerRemoveFailed(
+                    f"Failed remove remote runner: {runner.name}"
+                ) from e
 
         if runner.local:
             try:
@@ -258,7 +257,9 @@ class RunnerManager:
                     # surface.
                     runner.local.delete(wait=True)
             except Exception as e:
-                raise RunnerRemoveFailed(f"Failed remove local runner: {runner.name}") from e
+                raise RunnerRemoveFailed(
+                    f"Failed remove local runner: {runner.name}"
+                ) from e
 
     def _register_runner(self, container, labels):
         """Register a runner in a container"""

--- a/src/runner.py
+++ b/src/runner.py
@@ -152,7 +152,7 @@ class RunnerManager:
             r.name: r for r in remote_runners if r.name.startswith(f"{self.app_name}-")
         }
         runners = []
-        for name in set(local_runners.keys()) & set(remote_runners.keys()):
+        for name in set(local_runners.keys()) | set(remote_runners.keys()):
             runners.append(
                 RunnerInfo(name, local_runners.get(name), remote_runners.get(name))
             )

--- a/templates/dispatch-event.service.j2
+++ b/templates/dispatch-event.service.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Dispatch the {{event}} event on {{unit}}
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/juju-run "{{unit}}" "JUJU_DISPATCH_PATH={{event}} timeout {{timeout}} ./dispatch"
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/dispatch-event.timer.j2
+++ b/templates/dispatch-event.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Timer to dispatch {{event}} event periodically
+Requires=ghro.{{event}}.service
+
+[Timer]
+Unit=ghro.{{event}}.service
+OnUnitInactiveSec={{interval}}m
+RandomizedDelaySec={{jitter}}m
+
+[Install]
+WantedBy=timers.target

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -22,4 +22,4 @@ async def test_build_and_deploy(ops_test):
 
 async def test_status(units):
     assert units[0].workload_status == "blocked"
-    assert units[0].workload_status_message == "Waiting for Token and Path config"
+    assert units[0].workload_status_message == "Missing token or org/repo path config"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,30 +1,31 @@
+from functools import partial
 from unittest import mock
 
 import pytest
-from runner import Runner
+from runner import RunnerManager
+
+
+def _rm_factory_wrapper(tmp_path, rm_factory, *args, **kwargs):
+    runner_manager = rm_factory(*args, **kwargs)
+    runner_manager.runner_bin_path = tmp_path / "runner.tgz"
+    runner_manager.env_file = tmp_path / "env"
+    return runner_manager
 
 
 @pytest.fixture
-def runner(tmp_path_factory):
-    runner = Runner(path="mock-org", token="mock-token")
-    opt_path = tmp_path_factory.mktemp("runner")
-    runner.runner_path = opt_path
-    runner.env_file = opt_path / ".env"
-    return runner
+def runner_manager(tmp_path):
+    return _rm_factory_wrapper(
+        tmp_path, RunnerManager, "org", "token", "app", "container"
+    )
 
 
 @pytest.fixture(autouse=True)
-def mocks(monkeypatch):
-    monkeypatch.setattr("charm.CronTab", mock.MagicMock())
+def mocks(monkeypatch, tmp_path):
     monkeypatch.setattr("runner.GhApi", mock.MagicMock())
     monkeypatch.setattr("runner.pylxd", mock.MagicMock())
     monkeypatch.setattr("runner.requests", mock.MagicMock())
-    monkeypatch.setattr("runner.Runner._check_output", mock.MagicMock())
-    monkeypatch.setattr("runner.Runner._get_runner_binary", mock.MagicMock())
-    monkeypatch.setattr("runner.Runner._load_aaprofile", mock.MagicMock())
-
-    def active_count(runner_class, values=[0, 1, 2, 3]):
-        return values.pop(0)
-
-    monkeypatch.setattr("runner.Runner.active_count", active_count)
+    monkeypatch.setattr("runner.RunnerManager._check_output", mock.MagicMock())
     monkeypatch.setattr("runner.time", mock.MagicMock())
+    monkeypatch.setattr(
+        "charm.RunnerManager", partial(_rm_factory_wrapper, tmp_path, RunnerManager)
+    )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,27 +5,12 @@ import pytest
 from runner import RunnerManager
 
 
-def _rm_factory_wrapper(tmp_path, rm_factory, *args, **kwargs):
-    runner_manager = rm_factory(*args, **kwargs)
-    runner_manager.runner_bin_path = tmp_path / "runner.tgz"
-    runner_manager.env_file = tmp_path / "env"
-    return runner_manager
-
-
-@pytest.fixture
-def runner_manager(tmp_path):
-    return _rm_factory_wrapper(
-        tmp_path, RunnerManager, "org", "token", "app", "container"
-    )
-
-
 @pytest.fixture(autouse=True)
 def mocks(monkeypatch, tmp_path):
     monkeypatch.setattr("runner.GhApi", mock.MagicMock())
     monkeypatch.setattr("runner.pylxd", mock.MagicMock())
     monkeypatch.setattr("runner.requests", mock.MagicMock())
-    monkeypatch.setattr("runner.RunnerManager._check_output", mock.MagicMock())
     monkeypatch.setattr("runner.time", mock.MagicMock())
-    monkeypatch.setattr(
-        "charm.RunnerManager", partial(_rm_factory_wrapper, tmp_path, RunnerManager)
-    )
+    monkeypatch.setattr("runner.RunnerManager._check_output", mock.MagicMock())
+    monkeypatch.setattr("runner.RunnerManager.runner_bin_path", tmp_path / "runner.tgz")
+    monkeypatch.setattr("runner.RunnerManager.env_file", tmp_path / "env")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,8 +1,6 @@
-from functools import partial
 from unittest import mock
 
 import pytest
-from runner import RunnerManager
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -26,8 +26,8 @@ class TestCharm(unittest.TestCase):
         harness.update_config({"path": "mockorg", "token": "mocktoken"})
         harness.begin()
         harness.charm.on.config_changed.emit()
-        api = harness.charm._runner.api
-        api.actions.create_registration_token_for_org.assert_called_with(org="mockorg")
+        api = harness.charm.RunnerManager.GhApi()
+        api.actions.create_registration_token_for_org.assert_called_with(org="org")
 
     def test_repo_register(self):
         """Test repo registration"""
@@ -35,7 +35,7 @@ class TestCharm(unittest.TestCase):
         harness.update_config({"path": "mockorg/repo", "token": "mocktoken"})
         harness.begin()
         harness.charm.on.config_changed.emit()
-        api = harness.charm._runner.api
+        api = harness.charm.RunnerManager.GhApi()
         api.actions.create_registration_token_for_repo.assert_called_with(
             owner="mockorg", repo="repo"
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,35 +9,42 @@ from ops.testing import Harness
 
 
 class TestCharm(unittest.TestCase):
-    @patch("runner.subprocess")
-    def test_install(self, sp):
+    @patch("pathlib.Path.write_text")
+    @patch("subprocess.run")
+    def test_install(self, run, wt):
         harness = Harness(GithubRunnerOperator)
         harness.begin()
         harness.charm.on.install.emit()
         calls = [
-            call(["sudo", "snap", "install", "lxd"]),
-            call(["sudo", "lxd", "init", "--auto"]),
+            call(["snap", "install", "lxd"], check=True),
+            call(["lxd", "init", "--auto"], check=True),
         ]
-        sp.check_output.assert_has_calls(calls)
+        run.assert_has_calls(calls)
 
-    def test_org_register(self):
+    @patch("charm.RunnerManager")
+    @patch("pathlib.Path.write_text")
+    @patch("subprocess.run")
+    def test_org_register(self, run, wt, rm):
         """Test org registration"""
         harness = Harness(GithubRunnerOperator)
         harness.update_config({"path": "mockorg", "token": "mocktoken"})
         harness.begin()
         harness.charm.on.config_changed.emit()
-        api = harness.charm.RunnerManager.GhApi()
-        api.actions.create_registration_token_for_org.assert_called_with(org="org")
+        rm.assert_called_with(
+            "mockorg", "mocktoken", "github-runner-operator", "container"
+        )
 
-    def test_repo_register(self):
+    @patch("charm.RunnerManager")
+    @patch("pathlib.Path.write_text")
+    @patch("subprocess.run")
+    def test_repo_register(self, run, wt, rm):
         """Test repo registration"""
         harness = Harness(GithubRunnerOperator)
         harness.update_config({"path": "mockorg/repo", "token": "mocktoken"})
         harness.begin()
         harness.charm.on.config_changed.emit()
-        api = harness.charm.RunnerManager.GhApi()
-        api.actions.create_registration_token_for_repo.assert_called_with(
-            owner="mockorg", repo="repo"
+        rm.assert_called_with(
+            "mockorg/repo", "mocktoken", "github-runner-operator", "container"
         )
 
     # def test_add_cron(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [flake8]
 max-line-length = 88
+ignore =
+  E203
 
 [tox]
 skipsdist = True

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 max-line-length = 88
 ignore =
   E203
+  E503
 
 [tox]
 skipsdist = True
@@ -33,5 +34,5 @@ deps =
     black
     flake8
 commands =
-    flake8 {toxinidir}/tests {toxinidir}/src --ignore W503
+    flake8 {toxinidir}/tests {toxinidir}/src
     black --check --diff {toxinidir}/tests {toxinidir}/src


### PR DESCRIPTION
This refactor addresses several issues with how the runners are managed and kept up to date, including:

  * There were several possible infinite loops.
  * The runner binary update check was done every time a runner was created.
  * The runner binary update check wasn't using the API token and thus could hit the lower unauthenticated API limits.
  * Due to any and all of the above, the charm could get stuck in a blocked hook execution which would prevent it from recovering any runners.
  * Local runners could end up unregistered and never cleaned up, eventually blocking replacement runner registration.

Fixes #4