### PR TITLE
Replace once with ephemeral

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -73,7 +73,6 @@ class GithubRunnerOperator(CharmBase):
     def _reconcile_runners(self):
         delta = self.config["quantity"] - self._runner.active_count()
         logger.info(f"Reconciling {delta} runners")
-        self._runner.remove_runners()
         while delta > 0:
             self.unit.status = MaintenanceStatus(f"Installing {delta} runner(s)")
             try:

--- a/src/runner.py
+++ b/src/runner.py
@@ -147,6 +147,7 @@ class Runner:
             f"--url https://github.com/{self.path} "
             "--token "
             f"{token.token} "
+            "--ephemeral "
             "--unattended "
             "--labels "
             f"{','.join(labels)}"

--- a/src/runner.py
+++ b/src/runner.py
@@ -82,41 +82,24 @@ class Runner:
                 count += 1
         return count
 
-    def remove_runners(self, offline_only=True, timeout=30):
+    def remove_runners(self):
         """Remove runners"""
         api = self.api
         repo = None
         if "/" in self.path:
             owner, repo = self.path.split("/")
-        for id in self._find_offline_runners(timeout=timeout):
-            if repo:
-                api.actions.delete_self_hosted_runner_from_repo(
-                    owner=owner, repo=repo, runner_id=id
-                )
-            else:
-                api.actions.delete_self_hosted_runner_from_org(
-                    org=self.path, runner_id=id
-                )
-
-    def _find_offline_runners(self, timeout=30):
-        """Return a list of ids for offline runners"""
-        offline = []
-        offline_initial = []
+        hosted_runners = [container.name for container in self.lxd.containers.all()]
         for runner in self._get_runners()["runners"]:
-            if not runner.name.startswith("runner-"):
-                continue
-            if runner.status == "offline":
-                offline_initial.append(runner.id)
-        if not offline_initial:
-            return offline
-        time.sleep(timeout)
-        for runner in self._get_runners()["runners"]:
-            if not runner.name.startswith("runner-"):
-                continue
-            if runner.status == "offline":
-                if runner.id in offline_initial:
-                    offline.append(runner.id)
-        return offline
+            if runner.name in hosted_runners:
+                logger.info(f"Deregistering runner {runner.name}")
+                if repo:
+                    api.actions.delete_self_hosted_runner_from_repo(
+                        owner=owner, repo=repo, runner_id=runner.id
+                    )
+                else:
+                    api.actions.delete_self_hosted_runner_from_org(
+                        org=self.path, runner_id=runner.id
+                    )
 
     def _get_runners(self):
         """Return the runner data"""
@@ -148,6 +131,8 @@ class Runner:
             "--token "
             f"{token.token} "
             "--ephemeral "
+            "--name "
+            f"{container.name} "
             "--unattended "
             "--labels "
             f"{','.join(labels)}"

--- a/templates/start.j2
+++ b/templates/start.j2
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-(/opt/github-runner/run.sh --once; sudo systemctl halt -i) &>/dev/null &
+(/opt/github-runner/run.sh; sudo systemctl halt -i) &>/dev/null &


### PR DESCRIPTION
Use the newly supported `--ephemeral` on configure instead of `-once` on run.

This means that runners are automatically de registered once they have completed a job. Meaning charm code can be simplified somewhat.

In doing so, I have also included a bug fix which means runners are now correctly de registered when units are stopped

Fixes #15 